### PR TITLE
README Update and Typo Removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # CyberArkTools
 Some Python tooling to try to decrypt CyberArk .cred credential files
+
 Research: https://research.nccgroup.com/2021/10/08/reverse-engineering-and-decrypting-cyberark-vault-credential-files/
 
 ## Verification Flag Breakdown
-https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/PASIMP/CreateCredFile-Utility.htm#CreateCredFileparameters
+Vendor Documentation: https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/PASIMP/CreateCredFile-Utility.htm#CreateCredFileparameters
 ### Application Type (--appname)
 This restriction limits what application types are able to use the .cred file. The options for this are: 
 - CPM
@@ -21,16 +22,17 @@ This restriction limits what application types are able to use the .cred file. T
 - NAPI
 - EVD
 - CACrypt
+
 Source: https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/11.3/en/Content/PASIMP/CreateCredFile-Utility.htm
 
-### OS Username
+### OS Username (--username)
 The name of the user who can use this file. Typically specified in "domain\username" format. Example: SYSTEM -> "nt authority\system". This will normally also be a specific user created in the vault for initial setup purposes.
 
-### Executable Path
+### Executable Path (--exepath)
 Full path to the executable that is using the file.
 
-### Machine IP
+### Machine IP (--machineip)
 IP of the machine the .cred file is used on. In most cases this will be the local machine the file was found on, but CAN be a remote system.
 
-### Machine Hostname
+### Machine Hostname (--hostname)
 Hostname of the system the .cred file is used on. FQDN not required. In most cases this will be the local machine the file was found on, but CAN be a remote system.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # CyberArkTools
-Some Python tooling to for example try to decrypt CyberArk .cred credential files
+Some Python tooling to try to decrypt CyberArk .cred credential files
+Research: https://research.nccgroup.com/2021/10/08/reverse-engineering-and-decrypting-cyberark-vault-credential-files/
+
+## Verification Flag Breakdown
+https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/PASIMP/CreateCredFile-Utility.htm#CreateCredFileparameters
+### Application Type (--appname)
+This restriction limits what application types are able to use the .cred file. The options for this are: 
+- CPM
+- PVWA
+- PVWAApp
+- AppPrv
+- PSMApp
+- CABACKUP
+- DR
+- ENE
+- WINCLIENT
+- GUI
+- PACLI
+- XAPI
+- NAPI
+- EVD
+- CACrypt
+Source: https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/11.3/en/Content/PASIMP/CreateCredFile-Utility.htm
+
+### OS Username
+The name of the user who can use this file. Typically specified in "domain\username" format. Example: SYSTEM -> "nt authority\system". This will normally also be a specific user created in the vault for initial setup purposes.
+
+### Executable Path
+Full path to the executable that is using the file.
+
+### Machine IP
+IP of the machine the .cred file is used on. In most cases this will be the local machine the file was found on, but CAN be a remote system.
+
+### Machine Hostname
+Hostname of the system the .cred file is used on. FQDN not required. In most cases this will be the local machine the file was found on, but CAN be a remote system.

--- a/decrypt_credential_file.py
+++ b/decrypt_credential_file.py
@@ -183,7 +183,7 @@ def prepare_add_verification_attributes(args):
     if args.username:
         result[VerificationFlags.Username] = args.username
     if args.hostname:
-        result[VerificationFlags.Hostname] = args.hostname
+        result[VerificationFlags.MachineHostname] = args.hostname
     return result
 
 


### PR DESCRIPTION
Fixed python attribute error by changing line 186 VerificationFlags.Hostname to VerificationFlags.MachineHostname.

Readme was edited to include sources and a breakdown of flags, including a list of the apptype options.